### PR TITLE
refactor parameters

### DIFF
--- a/assets/params/all.yaml
+++ b/assets/params/all.yaml
@@ -21,137 +21,157 @@ _project:
 _defaults:
     genome: mm10
     feature identifiers: name
+    feature types:
+        Gene Expression:
+            - COO4671A1
+            - COO4671A2
+            - COO4671A3
+            - COO4671A4
+            - COO4671A5
+            - COO4671A6
+            - AHM4688A1
+            - AHM4688A2
+            - AHM4688A3
+            - AHM4688A7
+            - AHM4688A9
+            - AHM4688A11
+            - AHM4688A15
+            - AHM4688A17
+            - AHM4688A19
+            - AHM4688A21
+            - AHM4688A23
+            - AHM4688A25
+            - AHM4688A27
+        Chromatin Accessibility:
+            - AHM4688A4
+            - AHM4688A5
+            - AHM4688A6
+            - AHM4688A8
+            - AHM4688A10
+            - AHM4688A12
+            - AHM4688A16
+            - AHM4688A18
+            - AHM4688A20
+            - AHM4688A22
+            - AHM4688A24
+            - AHM4688A26
+            - AHM4688A28
 
-cell ranger and seurat:
-    _defaults:
-        feature types:
-            Gene Expression:
-                - COO4671A1
-                - COO4671A2
-                - COO4671A3
-                - COO4671A4
-                - COO4671A5
-                - COO4671A6
-        stages:
-            - quantification/cell ranger
-            - seurat/prepare/cell ranger
-        quantification method: cell ranger
-        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
-        fastq paths:
-            - inputs/data_nm322/220221_A01366_0148_AH7HYGDMXY/fastq
-            - inputs/data_nm322/220310_A01366_0156_AH5YTYDMXY/fastq
-            - inputs/data_nm322/220818_A01366_0266_BHCJK7DMXY/fastq
-            - inputs/data_nm322/230221_A01366_0353_AHNH37DSX5/fastq
+    fastq paths:
+        - inputs/data_nm322/220221_A01366_0148_AH7HYGDMXY/fastq
+        - inputs/data_nm322/220310_A01366_0156_AH5YTYDMXY/fastq
+        - inputs/data_nm322/220818_A01366_0266_BHCJK7DMXY/fastq
+        - inputs/data_nm322/230221_A01366_0353_AHNH37DSX5/fastq
+        - inputs/data_sa154/220406_A01366_0169_AHC3HVDMXY/fastq
+        - inputs/data_sa154/220407_A01366_0171_AH3W3LDRX2/fastq
+        - inputs/data_sa154/220420_A01366_0179_BH72WWDMXY/fastq
+        - inputs/data_sa154/220422_A01366_0180_BHJLLNDSX3/fastq
+        - inputs/data_sa154/220425_A01366_0182_BH7HJ3DMXY/fastq
+        - inputs/data_sa154/220428_A01366_0187_BHCFHLDMXY/fastq
+        - inputs/data_sa154/220505_A01366_0193_BHKC3MDSX3/fastq
+        - inputs/data_sa154/220526_A01366_0207_BHCGLCDMXY/fastq
+        - inputs/data_sa154/220531_A01366_0211_AHCGNYDMXY/fastq
+        - inputs/data_sa154/220615_A01366_0219_AHK7WHDSX3/fastq
+        - inputs/data_sa154/220726_A01366_0242_BHN3GKDSX3/fastq
+        - inputs/data_sa154/220726_A01366_0243_AH5KL2DRX2/fastq
+        - inputs/data_sa154/220823_A01366_0268_AH5HJJDRX2/fastq
+        - inputs/data_sa154/220826_A01366_0270_BHGFMVDMXY/fastq
+        - inputs/data_sa154/220907_A01366_0275_AHGFV2DMXY/fastq
+        - inputs/data_sa154/220920_A01366_0282_AHCMHFDRX2/fastq
+        - inputs/data_sa154/220922_A01366_0283_AHF7FYDMXY/fastq
+        - inputs/data_sa154/221117_A01366_0317_BHGG3KDMXY/fastq
+        - inputs/data_sa154/221118_A01366_0319_AH7GYHDRX2/fastq
+        - inputs/data_sa154/221215_A01366_0329_AH7VKTDSX5/fastq
+        - inputs/data_sa154/221215_A01366_0330_BHNGLVDRX2/fastq
+        - inputs/data_sa154/221222_A01366_0333_AHGMKHDMXY/fastq
+        - inputs/data_sa154/230105_A01366_0334_BHJJ5VDSX5/fastq
+        - inputs/data_sa154/230106_A01366_0336_AHKFGJDSX5/fastq
+        - inputs/data_sa154/230201_A01366_0347_AHVLN5DRX2/fastq
+        - inputs/data_sa154/230420_A01366_0377_AHNFLGDRX2/fastq
+        - inputs/data_sa154/230511_A01366_0386_AHKC5TDMXY/fastq
+        - inputs/data_sa154/230526_A01366_0392_AHF3LVDSX7/fastq
 
+_datasets:
     stella 120h rep1:
         description: PGCLC sorted by STELLA at 120 hours
         limsid: COO4671A1
         dataset tag: ST120R1
+        stages:
+            - quantification/cell ranger
+            - seurat/prepare/cell ranger
         # quantification path: inputs/cellranger_nm322/COO4671A1/outs
+        quantification method: cell ranger
+        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     pecam1 120h rep1:
         description: PGCLC sorted by PECAM1 at 120 hours
         limsid: COO4671A2
         dataset tag: P120R1
+        stages:
+            - quantification/cell ranger
+            - seurat/prepare/cell ranger
         # quantification path: inputs/cellranger_nm322/COO4671A2/outs
+        quantification method: cell ranger
+        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     ssea1 120h rep1:
         description: PGCLC sorted by SSEA1 at 120 hours
         limsid: COO4671A3
         dataset tag: SS120R1
+        stages:
+            - quantification/cell ranger
+            - seurat/prepare/cell ranger
         # quantification path: inputs/cellranger_nm322/COO4671A3/outs
+        quantification method: cell ranger
+        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     blimp1 + ssea1 120h rep1:
         description: PGCLC sorted by BLIMP1 and SSEA1 at 120 hours
         limsid: COO4671A4
         dataset tag: BS120R1
-        # quantification path: inputs/cellranger_nm322/COO4671A4/outs
-
-cell ranger arc and seurat:
-    _defaults:
-        fastq paths:
-            - inputs/data_sa154/220406_A01366_0169_AHC3HVDMXY/fastq
-            - inputs/data_sa154/220407_A01366_0171_AH3W3LDRX2/fastq
-            - inputs/data_sa154/220420_A01366_0179_BH72WWDMXY/fastq
-            - inputs/data_sa154/220422_A01366_0180_BHJLLNDSX3/fastq
-            - inputs/data_sa154/220425_A01366_0182_BH7HJ3DMXY/fastq
-            - inputs/data_sa154/220428_A01366_0187_BHCFHLDMXY/fastq
-            - inputs/data_sa154/220505_A01366_0193_BHKC3MDSX3/fastq
-            - inputs/data_sa154/220526_A01366_0207_BHCGLCDMXY/fastq
-            - inputs/data_sa154/220531_A01366_0211_AHCGNYDMXY/fastq
-            - inputs/data_sa154/220615_A01366_0219_AHK7WHDSX3/fastq
-            - inputs/data_sa154/220726_A01366_0242_BHN3GKDSX3/fastq
-            - inputs/data_sa154/220726_A01366_0243_AH5KL2DRX2/fastq
-            - inputs/data_sa154/220823_A01366_0268_AH5HJJDRX2/fastq
-            - inputs/data_sa154/220826_A01366_0270_BHGFMVDMXY/fastq
-            - inputs/data_sa154/220907_A01366_0275_AHGFV2DMXY/fastq
-            - inputs/data_sa154/220920_A01366_0282_AHCMHFDRX2/fastq
-            - inputs/data_sa154/220922_A01366_0283_AHF7FYDMXY/fastq
-            - inputs/data_sa154/221117_A01366_0317_BHGG3KDMXY/fastq
-            - inputs/data_sa154/221118_A01366_0319_AH7GYHDRX2/fastq
-            - inputs/data_sa154/221215_A01366_0329_AH7VKTDSX5/fastq
-            - inputs/data_sa154/221215_A01366_0330_BHNGLVDRX2/fastq
-            - inputs/data_sa154/221222_A01366_0333_AHGMKHDMXY/fastq
-            - inputs/data_sa154/230105_A01366_0334_BHJJ5VDSX5/fastq
-            - inputs/data_sa154/230106_A01366_0336_AHKFGJDSX5/fastq
-            - inputs/data_sa154/230201_A01366_0347_AHVLN5DRX2/fastq
-            - inputs/data_sa154/230420_A01366_0377_AHNFLGDRX2/fastq
-            - inputs/data_sa154/230511_A01366_0386_AHKC5TDMXY/fastq
-            - inputs/data_sa154/230526_A01366_0392_AHF3LVDSX7/fastq
-        feature types:
-            Gene Expression:
-                - AHM4688A1
-                - AHM4688A2
-                - AHM4688A3
-                - AHM4688A7
-                - AHM4688A9
-                - AHM4688A11
-                - AHM4688A15
-                - AHM4688A17
-                - AHM4688A19
-                - AHM4688A21
-                - AHM4688A23
-                - AHM4688A25
-                - AHM4688A27
-            Chromatin Accessibility:
-                - AHM4688A4
-                - AHM4688A5
-                - AHM4688A6
-                - AHM4688A8
-                - AHM4688A10
-                - AHM4688A12
-                - AHM4688A16
-                - AHM4688A18
-                - AHM4688A20
-                - AHM4688A22
-                - AHM4688A24
-                - AHM4688A26
-                - AHM4688A28
         stages:
-            - quantification/cell_ranger_arc
-            - seurat/prepare/cell_ranger_arc
-        # index path: inputs/cellranger_arc_ref
-        feature identifiers: name
-        quantification method: cell ranger arc
+            - quantification/cell ranger
+            - seurat/prepare/cell ranger
+        # quantification path: inputs/cellranger_nm322/COO4671A4/outs
+        quantification method: cell ranger
+        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     8 weeks sample1:
         description: 8 week old, replicate 1
+        dataset tag: 8WS1
         limsid:
             - AHM4688A1
             - AHM4688A4
+        stages:
+            - quantification/cell_ranger_arc
+            - seurat/prepare/cell_ranger_arc
         # quantification path: inputs/cellranger_sa154/8weeks_sample1/outs
+        quantification method: cell ranger arc
+        # index path: inputs/cellranger_arc_ref
 
     8 weeks sample2:
         description: 8 week old, replicate 2
+        dataset tag: 8WS2
         limsid:
             - AHM4688A2
             - AHM4688A5
+        stages:
+            - quantification/cell_ranger_arc
+            - seurat/prepare/cell_ranger_arc
         # quantification path: inputs/cellranger_sa154/8weeks_sample2/outs
+        quantification method: cell ranger arc
+        # index path: inputs/cellranger_arc_ref
 
     8 weeks sample3:
         description: 8 week old, replicate 3
+        dataset tag: 8WS3
         limsid:
             - AHM4688A3
             - AHM4688A6
+        stages:
+            - quantification/cell_ranger_arc
+            - seurat/prepare/cell_ranger_arc
         # quantification path: inputs/cellranger_sa154/8weeks_sample3/outs
+        quantification method: cell ranger arc
+        # index path: inputs/cellranger_arc_ref
 

--- a/assets/params/all.yaml
+++ b/assets/params/all.yaml
@@ -174,4 +174,3 @@ _datasets:
         # quantification path: inputs/cellranger_sa154/8weeks_sample3/outs
         quantification method: cell ranger arc
         # index path: inputs/cellranger_arc_ref
-

--- a/assets/params/scrna.yaml
+++ b/assets/params/scrna.yaml
@@ -31,15 +31,13 @@ _defaults:
             - COO4671A4
             - COO4671A5
             - COO4671A6
+    stages:
+        - quantification/cell ranger
+        - seurat/prepare/cell ranger
+    quantification method: cell ranger
+    index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
-cell ranger and seurat:
-    _defaults:
-        stages:
-            - quantification/cell ranger
-            - seurat/prepare/cell ranger
-        quantification method: cell ranger
-        index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
-
+_datasets:
     stella 120h rep1:
         description: PGCLC sorted by STELLA at 120 hours
         limsid: COO4671A1

--- a/assets/params/snmultiome.yaml
+++ b/assets/params/snmultiome.yaml
@@ -75,16 +75,14 @@ _defaults:
             - AHM4688A24
             - AHM4688A26
             - AHM4688A28
+    stages:
+        - quantification/cell_ranger_arc
+        - seurat/prepare/cell_ranger_arc
+    index path: inputs/cellranger_arc_ref
+    feature identifiers: name
+    quantification method: cell ranger arc
 
-seurat:
-    _defaults:
-        stages:
-            - quantification/cell_ranger_arc
-            - seurat/prepare/cell_ranger_arc
-        index path: inputs/cellranger_arc_ref
-        feature identifiers: name
-        quantification method: cell ranger arc
-
+_datasets:
     8 weeks sample1:
         description: 8 week old, replicate 1
         limsid:

--- a/bin/guess_scamp_file.py
+++ b/bin/guess_scamp_file.py
@@ -386,10 +386,9 @@ def main():
 			'fastq paths': fastq_paths,
 			'feature types': library_types,
 			'index path': dataset_index,
-			'stages': stages},
-		'analysis': {
-			'_defaults': {
-				'feature identifiers': 'name'}} | datasets}
+			'stages': stages,
+			'feature identifiers': 'name'},
+		'_datasets': datasets}
 
 	# write the above structure to a yaml file
 	write_formatted_scamp_file(params)

--- a/docs/content/usage-guides/analysis-configuration/_index.files/multiome-parameters.yaml
+++ b/docs/content/usage-guides/analysis-configuration/_index.files/multiome-parameters.yaml
@@ -30,14 +30,12 @@ _defaults:
             - AHM4688A5
             - AHM4688A6
     feature identifiers: name
+    stages:
+        - quantification/cell ranger arc
+        - seurat/prepare/cell ranger arc
+    genome: mm10_mcherry
 
-cell ranger arc and seurat:
-    _defaults:
-        stages:
-            - quantification/cell ranger arc
-            - seurat/prepare/cell ranger arc
-        genome: mm10_mcherry
-
+_datasets:
     8 weeks sample1:
         description: 8 weeks old, replicate 1
         limsid:

--- a/docs/content/usage-guides/analysis-configuration/_index.files/scrna-parameters.yaml
+++ b/docs/content/usage-guides/analysis-configuration/_index.files/scrna-parameters.yaml
@@ -23,15 +23,13 @@ _defaults:
             - COO4671A3
             - COO4671A4
     feature identifiers: name
+    stages:
+        - quantification/cell ranger
+        - seurat/prepare/cell ranger
+    index path: inputs/10x_indexes/refdata-cellranger-mm10-3.0.0
+    genome: mm10
 
-cell ranger and seurat:
-    _defaults:
-        stages:
-            - quantification/cell ranger
-            - seurat/prepare/cell ranger
-        index path: inputs/10x_indexes/refdata-cellranger-mm10-3.0.0
-        genome: mm10
-
+_datasets:
     stella 120h rep1:
         description: STELLA sorting at 120 hours
         limsid: COO4671A1

--- a/docs/content/usage-guides/analysis-configuration/_index.md
+++ b/docs/content/usage-guides/analysis-configuration/_index.md
@@ -14,13 +14,13 @@ These notes illustrate how to configure an analysis using {scamp}. Detailed desc
 
 A `parameters.yaml` file is used to described all aspects of a project and should serve as a record for parameters used in the pipeline. It will be passed to Nextflow as a parameter using `--scamp_file`.
 
-The structure of `parameters.yaml` allows aspects of a project to be recorded alongside multiple analyses that can contain multiple datasets in a plain text and human readable format. `parameters.yaml` keys that being with underscores are reserved by {scamp} and should not be used in other keys. At the first level, the project (`_project`) and analysis stanzas are specified, the latter can have any name but should be reasonably filename-safe. Within analysis stanzas there are datasets which can also be freely (but sensibly) named.
+The structure of `parameters.yaml` allows aspects of a project to be recorded alongside multiple analyses that can contain multiple datasets in a plain text and human readable format. `parameters.yaml` keys that being with underscores are reserved by {scamp} and should not be used in other keys. At the first level, the project (`_project`), common dataset parameters (`_defaults`) and dataset (`_dataset`) stanzas are specified. Within the datasets stanza, datasets can be freely (but sensibly) named.
 
 ## Example configuration file
 
 {{% attachments title="Related files" /%}}
 
-In this example for a scRNA-seq project, there are four datasets that will be quantified against mouse using the Cell Ranger mm10 reference from which Seurat objects will be prepared. To keep the file clear I tend to use symlinks in an `inputs` directory to other parts of the filesystem. The `inputs/primary_data` is a symlink to the ASF's outputs for this project and `inputs/10x_indexes` is a symlink to the communal 10X indexes resource.
+In this example for a scRNA-seq project, there are four datasets that will be quantified against mouse using the Cell Ranger mm10 reference from which Seurat objects will be prepared. To keep the file clear I have assumed symlinks in an `inputs` directory to other parts of the filesystem. The `inputs/primary_data` is a symlink to ASF's outputs for this project and `inputs/10x_indexes` is a symlink to the communal 10X indexes resource.
 
 {{< tabs title="Example parameters" >}}
 {{< tab title="scRNA-seq" >}}
@@ -36,25 +36,19 @@ In this example for a scRNA-seq project, there are four datasets that will be qu
 
 `_project` includes information about the project rather than parameters that should be applied to datasets.
 
-Most of the information in this stanza can be extracted a path on Nemo and/or the LIMS.
+Most of the information in this stanza can be extracted from a path on Nemo and/or the LIMS.
 
 The `genomes` stanza would be static across projects in most instances though the `ensembl release` is tied to any index against which the data is aligned or quantified (etc).
 
 ### Default project parameters
 
-These parameters are defined here for convenience. They will be aggregated into every dataset-level stanza in all analysis stanzas in the project, without overriding parameters defined in analyses or datasets. Depending on the analysis stages, different keys will be expected. In this example we are going to quantify expression of a scRNA-seq dataset so we need to know where the FastQ files are in the file system. The paths (not files) are specified here. The `feature_identifiers` will be used when the {Seurat} object is created; this will use the gene names (rather than Ensembl identifiers) as feature names.
+These parameters are defined here for convenience. They will be aggregated into every dataset in the `_datasets` stanza of the project, with the dataset-level parameter taking precedence. Depending on the analysis stages, different keys will be expected. In this example we are going to quantify expression of a scRNA-seq dataset so we need to know where the FastQ files are in the file system. The paths (not files) are specified here with `fastq files`. The `feature_identifiers` will be used when the Seurat object is created; specifying "names" will use the gene names (rather than Ensembl identifiers) as feature names.
 
-### Analysis stanzas
+The default parameters stanza typically contains a set of analysis stages, using the `stages` key. This curated list of keywords identifies which workflows should be applied to the dataset(s). In the example we specify two workflows: quantification by Cell Ranger and Seurat object creation. The order of the workflows is not important. The keywords to include can be found in the [workflows documentation][workflow docs].
 
-We can now specify multiple analyses to run different combinations of analysis stages. Analysis stanzas must have unique names and ideally not contain odd characters. {scamp} will _try_ to make the key directory-safe, however. Within each analysis stanza there is an optional `_default` and multiple dataset stanzas.
+The parameters defined here are a convenience to avoid copy/paste into each dataset stanza. Parameters defined in a dataset will still override parameters defined here.
 
-An analysis stanza typically contains a set of analysis stages, using the `stages` key. This curated list of keywords identifies which workflows should be applied to the dataset(s). In the example we specify two workflows: quantification by Cell Ranger and Seurat object creation. The order of the workflows is not important. The keywords to include can be found in the workflows documentation.
+### Datasets
 
-#### Default analysis parameters
-
-As with the project-level default parameters, the parameters defined here are a convenience to avoid copy/paste into each dataset stanza. Parameters defined in a dataset will still override parameters defined here.
-
-#### Dataset stanzas
-
-A set of datasets are defined with unique names. The parameters defined here are the highest priority and override the analysis- and project-level `_defaults`. The name of a dataset is free but should be sensible, {scamp} will attempt to make the name directory-safe by replacing non `a-z`, `0-9` or `.` characters to underscores.
+We can now describe the different datasets to which the analysis stages will be applied. Dataset stanzas must have unique names and ideally not contain odd characters. {scamp} will _try_ to make the key directory-safe, however.
 

--- a/docs/content/usage-guides/analysis-configuration/scrna/steps.json
+++ b/docs/content/usage-guides/analysis-configuration/scrna/steps.json
@@ -1,4 +1,3 @@
-
 {
 	"project" : {
 		"target": 1,
@@ -9,10 +8,9 @@
 		"title": "project defaults",
 		"text": "A set of parameters that are the same for <i>all</i> datasets in <i>all</i> analyses."},
 	"analysis" : {
-		"target": 27,
-		"title": "an analysis",
-		"text": "One or more analysis groups are defined. Each analysis can contain multiple datasets. These cannot start with underscores!"},
-
+		"target": 32,
+		"title": "project datasets",
+		"text": "Descriptions of each dataset to include in the analysis stages."},
 
 	"people" : {
 		"target": 2,
@@ -43,39 +41,33 @@
 		"target": 25,
 		"title": "identifiers",
 		"text": "Which feature identifier should be used as the default: probably <code>name</code> or <code>accession</code>."},
-
-	"analysis_defaults" : {
-		"target": 28,
-		"title": "analysis defaults",
-		"text": "As with project defaults, these parameters are applied to all datasets <emph>within this analysis</emph>."},
-	"dataset" : {
-		"target": 35,
-		"title": "a dataset",
-		"text": "The first (of four) datasets. Each dataset is specified in separate stanzas of the analysis. Dataset names should not start with underscores!"},
-
 	"stages" : {
-		"target": 29,
+		"target": 26,
 		"title": "analysis stages",
 		"text": "A list of workflows that should be applied to a dataset. In this example, these two workflows will be applied to all four datasets in the analysis."},
 	"index" : {
-		"target": 32,
+		"target": 29,
 		"title": "genome index",
 		"text": "The index against which the dataset(s) were quantified. This can be used by modules to get paths to GTF, FastA and FastA index files, for example."},
 	"genome" : {
-		"target": 33,
+		"target": 30,
 		"title": "genome",
 		"text": "The key that was used in <code>genomes</code> to identify a set of genome parameters. Multiple genomes can be used in the same project, but are likely best separated into different analyses."},
 
+	"dataset" : {
+		"target": 33,
+		"title": "a dataset",
+		"text": "The first (of four) datasets. Each dataset is specified in a separate stanza of <code>_datasets</code>."},
 	"description" : {
-		"target": 36,
+		"target": 34,
 		"title": "description",
 		"text": "A short description of this sample."},
 	"limsid" : {
-		"target": 37,
+		"target": 35,
 		"title": "LIMS ID",
-		"text": "The name(s) of libraries used to describe the dataset. In snRNA+ATAC for example, this would be an array of two libraries: one for the RNA-seq and another for the ATAC-seq."},
+		"text": "The name(s) of libraries used to describe the dataset. In snRNA+ATAC for example, this would be a collection of two libraries: one for the RNA-seq and another for the ATAC-seq."},
 	"dataset_tag" : {
-		"target": 38,
+		"target": 36,
 		"title": "dataset tag",
-		"text": "A short tag to describe a dataset that can be appended to cell barcodes to quickly discriminate originating dataset and uniquely identify cells in integrated objects."}
+		"text": "A short tag to describe a dataset that can be appended to cell barcodes to quickly discriminate originating dataset and uniquely identify cells in (Seurat) integrated objects."}
 }

--- a/main.yaml
+++ b/main.yaml
@@ -1,5 +1,5 @@
 - title: Analysis parameters
-  description: Any {scamp} parameter that can be provided in an analysis stanza, under the analysis or project `_defaults` or under a specific dataset's stanza.
+  description: Any {scamp} parameter that can be provided in the project `_defaults` stanza or under a specific dataset's stanza.
   icon: edit
   parameters:
     - name: fastq paths
@@ -35,14 +35,6 @@
       description: A very short name for the dataset. This will be appended to cell barcodes so should be _very_ short and concise with no spaces or funny characters. An unhelpful default will be provided but should not be trusted.
       type: string
       provider: default
-    - name: analysis name
-      description: A human-readable name for an analysis. This should not be applied at the dataset-level within an analysis stanza but could be specified in the `_defaults` for an analysis. The default is the YAML key used in the {scamp} parameters file.
-      type: string
-      provider: default
-    - name: analysis id
-      description: A directory safe identifier for the analysis. The default value is an attempt to make the `dataset name` directory-safe.
-      type: string
-      provider: default
     - name: dataset name
       description: Human readable name for a dataset in an analysis. The YAML key will be used if omitted.
       type: string
@@ -70,7 +62,7 @@
       description: A JASPAR-formatted file of motifs that can be used by Cell Ranger ARC to build an index. No default is provided.
       type: file
     - name: unique id
-      description: A unique identifer for this combination of analysis and dataset. By default, the analysis and dataset keys are joined together by " / ".
+      description: A unique identifer for this combination of analysis and dataset. By default, the dataset name is used.
       type: string
       provider: default
 

--- a/main.yaml
+++ b/main.yaml
@@ -62,7 +62,7 @@
       description: A JASPAR-formatted file of motifs that can be used by Cell Ranger ARC to build an index. No default is provided.
       type: file
     - name: unique id
-      description: A unique identifer for this combination of analysis and dataset. By default, the dataset name is used.
+      description: A unique identifer for this combination of analysis and dataset. By default, the dataset key is used.
       type: string
       provider: default
 


### PR DESCRIPTION
removes project-level analysis groups and uses only `_datasets` instead - basically each params file is one (old) analysis stanza 