### PR TITLE
use only one genome

### DIFF
--- a/assets/params/all.yaml
+++ b/assets/params/all.yaml
@@ -7,9 +7,9 @@ _project:
     babs id: sn002
 
 _genome:
+    assembly: mm10 + mCherry
     name: mm10 + mCherry
     organism: mus musculus
-    assembly: mm10_mcherry
     ensembl release: 98
     non-nuclear contigs:
         - chrM
@@ -18,7 +18,7 @@ _genome:
     fasta path: inputs/fastas
     gtf path: inputs/gtfs
     motifs file: inputs/motifs
-    # fasta file: inputs/fasta
+    # fasta file: inputs/fasta.fa
 
 _defaults:
     feature identifiers: name
@@ -97,11 +97,11 @@ _datasets:
         limsid: COO4671A1
         dataset tag: ST120R1
         stages:
-            # - quantification/cell ranger
-            # - seurat/prepare/cell ranger
+            - quantification/cell ranger
+            - seurat/prepare/cell ranger
         # quantification path: inputs/cellranger_nm322/COO4671A1/outs
         quantification method: cell ranger
-        index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
+        # index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     pecam1 120h rep1:
         description: PGCLC sorted by PECAM1 at 120 hours
@@ -169,7 +169,7 @@ _datasets:
             - AHM4688A3
             - AHM4688A6
         stages:
-            # - quantification/cell_ranger_arc
+            - quantification/cell_ranger_arc
             # - seurat/prepare/cell_ranger_arc
         # quantification path: inputs/cellranger_sa154/8weeks_sample3/outs
         quantification method: cell ranger arc

--- a/assets/params/all.yaml
+++ b/assets/params/all.yaml
@@ -5,28 +5,20 @@ _project:
     scientist: scientist.b
     lims id: SC23002
     babs id: sn002
-    genomes:
-        mm10:
-            organism: mus musculus
-            assembly: mm10
-            ensembl release: 98
-            non-nuclear contigs:
-                - chrM
-            mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
-            cell cycle genes: inputs/cell_cycle_genes/mus_musculus.yaml
-            fasta file: inputs/fasta.fa
-            # gtf file: inputs/gtf.gtf
-        mm10 + mcherry:
-            organism: mus musculus
-            assembly: mm10
-            ensembl release: 98
-            non-nuclear contigs:
-                - chrM
-            mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
-            cell cycle genes: inputs/cell_cycle_genes/mus_musculus.yaml
-            fasta path: inputs/fastas
-            gtf path: inputs/gtfs
-            motifs file: inputs/motifs.txt
+
+_genome:
+    name: mm10 + mCherry
+    organism: mus musculus
+    assembly: mm10_mcherry
+    ensembl release: 98
+    non-nuclear contigs:
+        - chrM
+    mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
+    cell cycle genes: inputs/cell_cycle_genes.yaml
+    fasta path: inputs/fastas
+    gtf path: inputs/gtfs
+    motifs file: inputs/motifs
+    # fasta file: inputs/fasta
 
 _defaults:
     feature identifiers: name
@@ -101,7 +93,6 @@ _defaults:
 
 _datasets:
     stella 120h rep1:
-        genome: mm10
         description: PGCLC sorted by STELLA at 120 hours
         limsid: COO4671A1
         dataset tag: ST120R1
@@ -113,7 +104,6 @@ _datasets:
         index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     pecam1 120h rep1:
-        genome: mm10
         description: PGCLC sorted by PECAM1 at 120 hours
         limsid: COO4671A2
         dataset tag: P120R1
@@ -125,7 +115,6 @@ _datasets:
         index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     ssea1 120h rep1:
-        genome: mm10
         description: PGCLC sorted by SSEA1 at 120 hours
         limsid: COO4671A3
         dataset tag: SS120R1
@@ -137,7 +126,6 @@ _datasets:
         index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     blimp1 + ssea1 120h rep1:
-        genome: mm10
         description: PGCLC sorted by BLIMP1 and SSEA1 at 120 hours
         limsid: COO4671A4
         dataset tag: BS120R1
@@ -149,7 +137,6 @@ _datasets:
         index path: /camp/svc/reference/Genomics/10x/10x_transcriptomes/refdata-cellranger-mm10-3.0.0
 
     8 weeks sample1:
-        genome: mm10 + mcherry
         description: 8 week old, replicate 1
         dataset tag: 8WS1
         limsid:
@@ -163,7 +150,6 @@ _datasets:
         # index path: inputs/cellranger_arc_ref
 
     8 weeks sample2:
-        genome: mm10 + mcherry
         description: 8 week old, replicate 2
         dataset tag: 8WS2
         limsid:
@@ -177,7 +163,6 @@ _datasets:
         # index path: inputs/cellranger_arc_ref
 
     8 weeks sample3:
-        genome: mm10 + mcherry
         description: 8 week old, replicate 3
         dataset tag: 8WS3
         limsid:

--- a/assets/params/all.yaml
+++ b/assets/params/all.yaml
@@ -170,7 +170,7 @@ _datasets:
             - AHM4688A6
         stages:
             - quantification/cell_ranger_arc
-            # - seurat/prepare/cell_ranger_arc
+            - seurat/prepare/cell_ranger_arc
         # quantification path: inputs/cellranger_sa154/8weeks_sample3/outs
         quantification method: cell ranger arc
         # index path: inputs/cellranger_arc_ref

--- a/assets/params/scrna.yaml
+++ b/assets/params/scrna.yaml
@@ -5,22 +5,22 @@ _project:
     scientist: scientist.b
     lims id: SC23002
     babs id: sn002
-    genomes:
-        mm10:
-            organism: mus musculus
-            assembly: mm10
-            ensembl release: 98
-            non-nuclear contigs:
-                - chrM
-            mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
-            cell cycle genes: inputs/cell_cycle_genes/mus_musculus.yaml
-            # fasta path: inputs/fastas
-            # gtf path: inputs/gtfs
-            fasta file: inputs/fasta.fa
-            gtf file: inputs/gtf.gtf
+
+_genome:
+    name: mm10:
+    organism: mus musculus
+    assembly: mm10
+    ensembl release: 98
+    non-nuclear contigs:
+        - chrM
+    mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
+    cell cycle genes: inputs/cell_cycle_genes/mus_musculus.yaml
+    # fasta path: inputs/fastas
+    # gtf path: inputs/gtfs
+    fasta file: inputs/fasta.fa
+    gtf file: inputs/gtf.gtf
 
 _defaults:
-    genome: mm10
     fastq paths:
         - inputs/data_nm322/220221_A01366_0148_AH7HYGDMXY/fastq
         - inputs/data_nm322/220310_A01366_0156_AH5YTYDMXY/fastq

--- a/assets/params/snmultiome.yaml
+++ b/assets/params/snmultiome.yaml
@@ -5,22 +5,22 @@ _project:
     scientist: scientist.a
     lims id: SC23001
     babs id: sn001
-    genomes:
-        mm10 + mcherry:
-            organism: mus musculus
-            assembly: mm10_mcherry
-            ensembl release: 98
-            non-nuclear contigs:
-                - chrM
-            mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
-            cell cycle genes: inputs/cell_cycle_genes.yaml
-            fasta path: inputs/fastas
-            gtf path: inputs/gtfs
-            motifs file: inputs/motifs
-            # fasta file: inputs/fasta
+
+_genome:
+    name: mm10 + mCherry
+    organism: mus musculus
+    assembly: mm10_mcherry
+    ensembl release: 98
+    non-nuclear contigs:
+        - chrM
+    mitochondrial features: inputs/mm10_mitochondrial_genes.yaml
+    cell cycle genes: inputs/cell_cycle_genes.yaml
+    fasta path: inputs/fastas
+    gtf path: inputs/gtfs
+    motifs file: inputs/motifs
+    # fasta file: inputs/fasta
 
 _defaults:
-    genome: mm10 + mcherry
     fastq paths:
         - inputs/data_sa154/220406_A01366_0169_AHC3HVDMXY/fastq
         - inputs/data_sa154/220407_A01366_0171_AH3W3LDRX2/fastq

--- a/bin/populate_docs_with_readmes.sh
+++ b/bin/populate_docs_with_readmes.sh
@@ -1,29 +1,30 @@
 #! /bin/env bash
 
 cd docs || exit
+rm -r content/{modules,utilities,workflows} content/usage-guides/user-parameters
 
 # make modules documentation
 find scamp/modules -name 'readme.yaml' |
 	sed -e 's|^scamp/||' -e 's|/readme.yaml$||' |
-	xargs -I @ sh -c "SCAMP_DOC=scamp/@/readme.yaml hugo new --kind doc-module --force @.md"
+	xargs -I @ sh -c "SCAMP_DOC=scamp/@/readme.yaml hugo new --kind doc-module @.md"
+
+# make utilities documentation
+find scamp/utilities -name 'main.yaml' |
+	sed -e 's|^scamp/||' -e 's|/main.yaml$||' |
+	xargs -I @ sh -c "SCAMP_DOC=scamp/@/main.yaml hugo new --kind doc-utility @.md"
 
 # make workflows documentation
 find scamp/workflows -name 'readme.yaml' |
 	sed -e 's|^scamp/||' -e 's|/readme.yaml$||' |
-	xargs -I @ sh -c "SCAMP_DOC=scamp/@/readme.yaml hugo new --kind doc-workflow --force @/_index.md"
+	xargs -I @ sh -c "SCAMP_DOC=scamp/@/readme.yaml hugo new --kind doc-workflow @/_index.md"
 
-find scamp/utilities -name 'main.yaml' |
-	sed -e 's|^scamp/||' -e 's|/main.yaml$||' |
-	xargs -I @ sh -c "SCAMP_DOC=scamp/@/main.yaml hugo new --kind doc-utility --force @.md"
-
-SCAMP_DOC=scamp/main.yaml hugo new --kind doc-user-parameters --force usage-guides/user-parameters/_index.md
+SCAMP_DOC=scamp/main.yaml hugo new --kind doc-user-parameters usage-guides/user-parameters/_index.md
 
 # make directory listings where _index.md is not found
-find content/{modules,workflows,utilities} -mindepth 0 -type d -not -exec test -e '{}/_index.md' ';' -print |
-	xargs -I @ sh -c "hugo new --kind docs-group --force @/_index.md"
+find content/{modules,utilities,workflows} -mindepth 0 -type d -not -exec test -e '{}/_index.md' ';' -print |
+	xargs -I @ sh -c "hugo new --kind docs-group @/_index.md"
 
 # set ordering for documentation
 sed -i 's/weight: /weight: 101/' content/modules/_index.md
-sed -i 's/weight: /weight: 102/' content/workflows/_index.md
 sed -i 's/weight: /weight: 103/' content/utilities/_index.md
-
+sed -i 's/weight: /weight: 102/' content/workflows/_index.md

--- a/docs/archetypes/docs-group.md
+++ b/docs/archetypes/docs-group.md
@@ -3,6 +3,8 @@ title: {{ .Name }}
 weight: 
 ---
 
+<!--more-->
+
 {{% children
 	containerstyle="ul"
 	style="li"

--- a/docs/content/usage-guides/analysis-configuration/_index.files/multiome-parameters.yaml
+++ b/docs/content/usage-guides/analysis-configuration/_index.files/multiome-parameters.yaml
@@ -4,15 +4,15 @@ _project:
     lims id: SC22051
     babs id: sa145
     type: 10X-Multiomics
-    genomes:
-        mm10_mcherry:
-            organism: mus musculus
-            assembly: mm10
-            ensembl release: 98
-            non-nuclear contigs:
-                - chrM
-            fasta files: inputs/fasta
-            gtf files: inputs/gtf
+
+_genome:
+    assembly: mm10 + mCherry
+    organism: mus musculus
+    ensembl release: 98
+    non-nuclear contigs:
+        - chrM
+    fasta path: inputs/fastas
+    gtf path: inputs/gtfs
 
 _defaults:
     fastq paths:
@@ -33,7 +33,6 @@ _defaults:
     stages:
         - quantification/cell ranger arc
         - seurat/prepare/cell ranger arc
-    genome: mm10_mcherry
 
 _datasets:
     8 weeks sample1:

--- a/docs/content/usage-guides/analysis-configuration/_index.files/scrna-parameters.yaml
+++ b/docs/content/usage-guides/analysis-configuration/_index.files/scrna-parameters.yaml
@@ -4,11 +4,14 @@ _project:
     lims id: SC22034
     babs id: nm322
     type: 10X-3prime
-    genomes:
-        mm10:
-            organism: mus musculus
-            assembly: mm10
-            ensembl release: 98
+
+_genome:
+    organism: mus musculus
+    assembly: mm10
+    ensembl release: 98
+    fasta file: inputs/10x_indexes/refdata-gex-mm10-2020-A/fasta/genome.fa
+    fasta index file: inputs/10x_indexes/refdata-gex-mm10-2020-A/fasta/genome.fa.fai
+    gtf file: inputs/10x_indexes/refdata-gex-mm10-2020-A/genes/genes.gtf
 
 _defaults:
     fastq paths:
@@ -27,7 +30,6 @@ _defaults:
         - quantification/cell ranger
         - seurat/prepare/cell ranger
     index path: inputs/10x_indexes/refdata-cellranger-mm10-3.0.0
-    genome: mm10
 
 _datasets:
     stella 120h rep1:

--- a/docs/content/usage-guides/analysis-configuration/_index.md
+++ b/docs/content/usage-guides/analysis-configuration/_index.md
@@ -12,15 +12,15 @@ These notes illustrate how to configure an analysis using {scamp}. Detailed desc
 
 ## Analysis configuration
 
-A `parameters.yaml` file is used to described all aspects of a project and should serve as a record for parameters used in the pipeline. It will be passed to Nextflow as a parameter using `--scamp_file`.
+A parameters YAML file is used to described all aspects of a project and should serve as a record for parameters used in the pipeline. It will be passed to Nextflow as a parameter using `--scamp_file`.
 
-The structure of `parameters.yaml` allows aspects of a project to be recorded alongside multiple analyses that can contain multiple datasets in a plain text and human readable format. `parameters.yaml` keys that being with underscores are reserved by {scamp} and should not be used in other keys. At the first level, the project (`_project`), common dataset parameters (`_defaults`) and dataset (`_dataset`) stanzas are specified. Within the datasets stanza, datasets can be freely (but sensibly) named.
+The structure of parameters file allows aspects of a project to be recorded alongside analysis parameters that can be specified for multiple datasets in a plain text and human-readable format. Parameter keys that begin with underscores are reserved by {scamp} and should not be used in other keys. At the first level, the project (`_project`), genome (`_genome`), common dataset parameters (`_defaults`) and dataset (`_dataset`) stanzas are specified. Within the datasets stanza, datasets can be freely (but sensibly) named.
 
 ## Example configuration file
 
 {{% attachments title="Related files" /%}}
 
-In this example for a scRNA-seq project, there are four datasets that will be quantified against mouse using the Cell Ranger mm10 reference from which Seurat objects will be prepared. To keep the file clear I have assumed symlinks in an `inputs` directory to other parts of the filesystem. The `inputs/primary_data` is a symlink to ASF's outputs for this project and `inputs/10x_indexes` is a symlink to the communal 10X indexes resource.
+In this example for a scRNA-seq project, there are four datasets that will be quantified against mouse using the Cell Ranger mm10 reference from which Seurat objects will be prepared. To keep the file clear I have assumed symlinks are available in an `inputs` directory to other parts of the filesystem. The `inputs/primary_data` is a symlink to ASF's outputs for this project and `inputs/10x_indexes` is a symlink to the communal 10X indexes resource.
 
 {{< tabs title="Example parameters" >}}
 {{< tab title="scRNA-seq" >}}
@@ -32,23 +32,10 @@ In this example for a scRNA-seq project, there are four datasets that will be qu
 {{< /tab >}}
 {{< /tabs >}}
 
-### Project description
+`_project` includes information about the project rather than parameters that should be applied to datasets. Most of the information in this stanza can be extracted from a path on Nemo and/or the LIMS.
 
-`_project` includes information about the project rather than parameters that should be applied to datasets.
+The `_genome` stanza is static across most projects though the `ensembl release` is tied to any index against which the data is aligned or quantified (etc).
 
-Most of the information in this stanza can be extracted from a path on Nemo and/or the LIMS.
+`_defaults` describes parameters that will be aggregated into every dataset in the `_datasets` stanza of the project, with the dataset-level parameter taking precedence. (So we don't have a big copy/paste list of parameters). Depending on the analysis stages, different keys will be expected. In this example we are going to quantify expression of a scRNA-seq dataset so we need to know where the FastQ files are in the file system. The paths (not files) are specified here with `fastq paths`. The `feature_identifiers` will be used when the Seurat object is created; specifying "names" will use the gene names (rather than Ensembl identifiers) as feature names. The default parameters stanza typically contains a set of analysis stages, using the `stages` key. This curated list of keywords identifies which workflows should be applied to the dataset(s). In the example we specify two workflows: quantification by Cell Ranger and Seurat object creation. The order of the workflows is not important. The keywords to include can be found in the [workflows documentation][workflow docs].
 
-The `genomes` stanza would be static across projects in most instances though the `ensembl release` is tied to any index against which the data is aligned or quantified (etc).
-
-### Default project parameters
-
-These parameters are defined here for convenience. They will be aggregated into every dataset in the `_datasets` stanza of the project, with the dataset-level parameter taking precedence. Depending on the analysis stages, different keys will be expected. In this example we are going to quantify expression of a scRNA-seq dataset so we need to know where the FastQ files are in the file system. The paths (not files) are specified here with `fastq files`. The `feature_identifiers` will be used when the Seurat object is created; specifying "names" will use the gene names (rather than Ensembl identifiers) as feature names.
-
-The default parameters stanza typically contains a set of analysis stages, using the `stages` key. This curated list of keywords identifies which workflows should be applied to the dataset(s). In the example we specify two workflows: quantification by Cell Ranger and Seurat object creation. The order of the workflows is not important. The keywords to include can be found in the [workflows documentation][workflow docs].
-
-The parameters defined here are a convenience to avoid copy/paste into each dataset stanza. Parameters defined in a dataset will still override parameters defined here.
-
-### Datasets
-
-We can now describe the different datasets to which the analysis stages will be applied. Dataset stanzas must have unique names and ideally not contain odd characters. {scamp} will _try_ to make the key directory-safe, however.
-
+Each dataset is described in `_datasets`. Dataset stanzas must have unique names and ideally not contain odd characters. {scamp} will _try_ to make the key directory-safe, however.

--- a/docs/content/usage-guides/analysis-configuration/scrna/steps.json
+++ b/docs/content/usage-guides/analysis-configuration/scrna/steps.json
@@ -3,14 +3,18 @@
 		"target": 1,
 		"title": "project description",
 		"text": "Parameters that define the project as a whole."},
+	"genome" : {
+		"target": 8,
+		"title": "genome used in the project",
+		"text": "Parameters that are independent of the dataset and analysis that describe the genome."},
 	"project_defaults" : {
-		"target": 13,
+		"target": 16,
 		"title": "project defaults",
-		"text": "A set of parameters that are the same for <i>all</i> datasets in <i>all</i> analyses."},
+		"text": "A set of parameters that are the same for <emph>all</emph> datasets in <code>_datasets</code>."},
 	"analysis" : {
-		"target": 32,
+		"target": 34,
 		"title": "project datasets",
-		"text": "Descriptions of each dataset to include in the analysis stages."},
+		"text": "Descriptions of each dataset to include in the project."},
 
 	"people" : {
 		"target": 2,
@@ -24,50 +28,42 @@
 		"target": 6,
 		"title": "project type",
 		"text": "A curated identifier for the project type which should be the same as used by ASF. This is included in the project design file in the <code>data</code> directory or in the LIMS."},
-	"genomes" : {
-		"target": 7,
-		"title": "genomes in the project",
-		"text": "A list of genomes used in the project, a dataset is linked to one of the <code>genomes</code> by the <code>genome</code> key of a dataset."},
 
 	"fastq_paths" : {
-		"target": 14,
+		"target": 17,
 		"title": "paths to FastQ files",
 		"text": "A list of paths that can be searched that may have a FastQ (<code>*.fastq.gz</code> file for one or more of the datasets."},
 	"feature_types" : {
-		"target": 19,
+		"target": 22,
 		"title": "assay types",
 		"text": "A list of LIMS IDs for each curated type of data. The <code>feature_types</code> keys depend on the data type and application. For example, Cell Ranger ARC expects <code>Gene Expression</code> and <code>Chromatin Accessibility</code> feature types."},
 	"feature_identifiers" : {
-		"target": 25,
+		"target": 28,
 		"title": "identifiers",
 		"text": "Which feature identifier should be used as the default: probably <code>name</code> or <code>accession</code>."},
 	"stages" : {
-		"target": 26,
+		"target": 29,
 		"title": "analysis stages",
 		"text": "A list of workflows that should be applied to a dataset. In this example, these two workflows will be applied to all four datasets in the analysis."},
 	"index" : {
-		"target": 29,
+		"target": 32,
 		"title": "genome index",
 		"text": "The index against which the dataset(s) were quantified. This can be used by modules to get paths to GTF, FastA and FastA index files, for example."},
-	"genome" : {
-		"target": 30,
-		"title": "genome",
-		"text": "The key that was used in <code>genomes</code> to identify a set of genome parameters. Multiple genomes can be used in the same project, but are likely best separated into different analyses."},
 
 	"dataset" : {
-		"target": 33,
+		"target": 35,
 		"title": "a dataset",
 		"text": "The first (of four) datasets. Each dataset is specified in a separate stanza of <code>_datasets</code>."},
 	"description" : {
-		"target": 34,
+		"target": 36,
 		"title": "description",
 		"text": "A short description of this sample."},
 	"limsid" : {
-		"target": 35,
+		"target": 37,
 		"title": "LIMS ID",
 		"text": "The name(s) of libraries used to describe the dataset. In snRNA+ATAC for example, this would be a collection of two libraries: one for the RNA-seq and another for the ATAC-seq."},
 	"dataset_tag" : {
-		"target": 36,
+		"target": 38,
 		"title": "dataset tag",
 		"text": "A short tag to describe a dataset that can be appended to cell barcodes to quickly discriminate originating dataset and uniquely identify cells in (Seurat) integrated objects."}
 }

--- a/main.nf
+++ b/main.nf
@@ -9,10 +9,10 @@ include { seurat }             from './workflows/seurat'
 
 include { print_as_json } from './utilities/print_as_json'
 
-include { concat_workflow_emissions }        from './utilities/concat_workflow_emissions'
-include { get_complete_analysis_parameters } from './utilities/get_complete_analysis_parameters'
-include { make_map }                         from './utilities/make_map'
-include { print_pipeline_title }             from './utilities/print_pipeline_title'
+include { concat_workflow_emissions } from './utilities/concat_workflow_emissions'
+include { make_map }                  from './utilities/make_map'
+include { parse_scamp_parameters }    from './utilities/parse_scamp_parameters'
+include { print_pipeline_title }      from './utilities/print_pipeline_title'
 
 print_pipeline_title()
 
@@ -28,7 +28,7 @@ workflow {
 		// -------------------------------------------------------------------------------------------------
 
 		channel
-			.fromList(get_complete_analysis_parameters())
+			.fromList(parse_scamp_parameters())
 			.dump(tag: 'scamp:parsed_scamp_parameters', pretty: true)
 			.set{parsed_scamp_parameters}
 

--- a/main.nf
+++ b/main.nf
@@ -29,16 +29,15 @@ workflow {
 
 		channel
 			.fromList(get_complete_analysis_parameters())
-			.dump(tag: 'parsed_scamp_parameters', pretty: true)
+			.dump(tag: 'scamp:parsed_scamp_parameters', pretty: true)
 			.set{parsed_scamp_parameters}
 
 		// -------------------------------------------------------------------------------------------------
 		// run genome workflow, independent of dataset parameters
 		// -------------------------------------------------------------------------------------------------
 
-		genome_preparation(parsed_scamp_parameters)
-			.result
-			.dump(tag: 'complete_analysis_parameters', pretty: true)
+		genome_preparation(parsed_scamp_parameters).result
+			.dump(tag: 'scamp:complete_analysis_parameters', pretty: true)
 			.set{complete_analysis_parameters}
 
 		// -------------------------------------------------------------------------------------------------
@@ -50,8 +49,8 @@ workflow {
 			.branch{
 				def has_a_quantification_stage = it.get('stages').collect{it.startsWith('quantification:')}.any()
 				def quantification_provided = it.containsKey('quantification path')
-				provided: quantification_provided == true
-				required: has_a_quantification_stage == true && quantification_provided == false}
+				provided: quantification_provided
+				required: has_a_quantification_stage & !quantification_provided}
 			.set{dataset_quantification}
 
 		dataset_quantification.required.dump(tag: 'scamp:dataset_quantification.required', pretty: true)
@@ -75,7 +74,7 @@ workflow {
 		quantification_results
 			.branch{
 				def has_a_seurat_stage = it.get('stages').collect{it.startsWith('seurat:')}.any()
-				seurat: has_a_seurat_stage == true
+				seurat: has_a_seurat_stage
 				unknown: true
 			}
 			.set{analysis_workflows}

--- a/main.yaml
+++ b/main.yaml
@@ -25,11 +25,6 @@
       type: path
       provider: process
 
-    - name: genome
-      description: Name of the genome for an analysis; must be one of `genomes`. The default value will be the first genome in `genomes`.
-      type: string
-      provider: default
-
     - name: description
       description: A short textual description of the dataset, mainly as an aide-memoire. A default value of `dataset name` is used if missing.
       type: string
@@ -65,27 +60,6 @@
       type: string
       provider: process
 
-    - name: fasta path
-      description: A directory with FastA files that can be used to create a genome index. When provided, the files in the directory will be concatenated together into a genome FastA.No default is provided but is probably only needed to build an index.
-      type: path
-
-    - name: fasta file
-      description: Genomic sequence in FastA format. Can be provided by the `fasta path` option. This parameter takes precedence over the `fasta path` parameter.
-      type: file
-      provider: process
-
-    - name: gtf path
-      description: A directory with GTF files that can be used to quantify activity of features. The files in this directory will be concatenated into a single GTF file and the result used in `gtf file`. No default is provided but is probably only needed to build an index.
-      type: path
-
-    - name: gtf file
-      description: GTF file of features in the genome. This parameter will be used in preference to the `gtf path`.
-      provider: process
-
-    - name: motifs file
-      description: A JASPAR-formatted file of motifs that can be used by Cell Ranger ARC to build an index. No default is provided.
-      type: file
-
     - name: unique id
       description: A unique identifer for this combination of analysis and dataset. By default, the dataset key is used.
       type: string
@@ -118,10 +92,6 @@
       type: string
       provider: default
 
-    - name: genomes
-      description: A dictionary of genomes included in the project. These should be very similar across projects and use standard values. The values may be dependent on other project parameters; the index used for alignment and quantification may be linked to `ensembl release` for example.
-      type: dictionary
-
 - title: Genome parameters
   description: A dictionary of parameters that define a genome. This can be used to define the parameters for a custom genome.
   icon: vial
@@ -142,6 +112,32 @@
     - name: non-nuclear contigs
       description: A collection of chromosomes in the `genome` that may be treated differently - for example by Cell Ranger ARC to created an index.
       type: strings
+
+    - name: id
+      description: A deirectory-safe name of the genome, which will be converted from `assembly` if missing.
+      type: string
+      provider: default
+
+    - name: fasta path
+      description: A directory with FastA files that can be used to create a genome index. When provided, the files in the directory will be concatenated together into a genome FastA.No default is provided but is probably only needed to build an index.
+      type: path
+
+    - name: fasta file
+      description: Genomic sequence in FastA format. Can be provided by the `fasta path` option. This parameter takes precedence over the `fasta path` parameter.
+      type: file
+      provider: process
+
+    - name: gtf path
+      description: A directory with GTF files that can be used to quantify activity of features. The files in this directory will be concatenated into a single GTF file and the result used in `gtf file`. No default is provided but is probably only needed to build an index.
+      type: path
+
+    - name: gtf file
+      description: GTF file of features in the genome. This parameter will be used in preference to the `gtf path`.
+      provider: process
+
+    - name: motifs file
+      description: A JASPAR-formatted file of motifs that can be used by Cell Ranger ARC to build an index. No default is provided.
+      type: file
 
 - title: Nextflow parameters
   description: Parameters used by the pipeline but are not directly part of {scamp} and specified with the `--` command line option. Default values are defined in `params.config`.

--- a/main.yaml
+++ b/main.yaml
@@ -109,7 +109,7 @@
       type: strings
 
     - name: id
-      description: A deirectory-safe name of the genome, which will be converted from `assembly` if missing.
+      description: A directory-safe name of the genome, which will be converted from `assembly` if missing.
       type: string
       provider: default
 

--- a/utilities/get_complete_analysis_parameters/main.nf
+++ b/utilities/get_complete_analysis_parameters/main.nf
@@ -48,7 +48,6 @@ def get_complete_analysis_parameters(stage=null) {
 def get_genome_params() {
 	def genome_params = get_scamp_params().get('_genome')
 	genome_params
-		.plus(['name': genome_params.get('name', 'genome')])
 		.plus(['id': make_string_directory_safe(genome_params.get('id', genome_params.get('name')))])
 }
 

--- a/utilities/get_complete_analysis_parameters/main.nf
+++ b/utilities/get_complete_analysis_parameters/main.nf
@@ -19,12 +19,18 @@ def get_complete_analysis_parameters(stage=null) {
 		// collect hashes into a collection of maps
 		.collect{k,v -> v}
 
+		// add genome parameters to each dataset
+		.collect{it + ['genome parameters': genome_params]}
+
+		// add default values to each set of dataset parameters
+		.collect{default_dataset_params + it}
+
 		// add default values where parameters are omitted
 		.collect{it + ['dataset name': it.get('dataset name', it.get('dataset key'))]}                          // dataset names
 		.collect{it + ['dataset id': make_string_directory_safe(it.get('dataset id', it.get('dataset name')))]} // dataset ids
 		.collect{it + ['dataset tag': it.get('dataset tag', it.get('dataset id'))]}                             // dataset tags
 		.collect{it + ['description': it.get('description', it.get('dataset name'))]}                           // dataset descriptions
-		.collect{it + ['feature identifiers': it.get('feature identifiers', 'name') ?: 'name']}                           // feature identifiers
+		.collect{it + ['feature identifiers': it.get('feature identifiers', 'name')]}                           // feature identifiers
 
 		// add default values to each set of dataset parameters
 		.collect{default_dataset_params + it}

--- a/utilities/get_complete_analysis_parameters/main.nf
+++ b/utilities/get_complete_analysis_parameters/main.nf
@@ -24,7 +24,7 @@ def get_complete_analysis_parameters(stage=null) {
 		.collect{it + ['dataset id': make_string_directory_safe(it.get('dataset id', it.get('dataset name')))]} // dataset ids
 		.collect{it + ['dataset tag': it.get('dataset tag', it.get('dataset id'))]}                             // dataset tags
 		.collect{it + ['description': it.get('description', it.get('dataset name'))]}                           // dataset descriptions
-		.collect{it + ['feature identifiers': it.get('feature identifiers', 'name')]}                           // feature identifiers
+		.collect{it + ['feature identifiers': it.get('feature identifiers', 'name') ?: 'name']}                           // feature identifiers
 
 		// add default values to each set of dataset parameters
 		.collect{default_dataset_params + it}
@@ -48,7 +48,7 @@ def get_complete_analysis_parameters(stage=null) {
 def get_genome_params() {
 	def genome_params = get_scamp_params().get('_genome')
 	genome_params
-		.plus(['id': make_string_directory_safe(genome_params.get('id', genome_params.get('name')))])
+		.plus(['id': make_string_directory_safe(genome_params.get('id', genome_params.get('assembly')))])
 }
 
 // get a hash of default parameters to use in all datasets

--- a/utilities/parse_scamp_parameters/main.nf
+++ b/utilities/parse_scamp_parameters/main.nf
@@ -5,7 +5,7 @@ include { make_string_directory_safe } from '../make_string_directory_safe'
 include { pluck }                      from '../pluck'
 include { remove_keys_from_map }       from '../remove_keys_from_map'
 
-def get_complete_analysis_parameters(stage=null) {
+def parse_scamp_parameters(stage=null) {
 	def genome_params = get_genome_params()
 	def default_dataset_params = get_default_dataset_params()
 	def possible_file_keys = get_possible_file_keys()

--- a/workflows/genome_preparation/main.nf
+++ b/workflows/genome_preparation/main.nf
@@ -153,7 +153,7 @@ workflow genome_preparation {
 		granges_file.to_skip.dump(tag: 'genome_preparation:granges_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		genomes = granges_file.to_make.map{it.get('name')}
+		genomes = granges_file.to_make.map{it.get('assembly')}
 		gtfs    = granges_file.to_make.map{it.get('gtf file')}
 		fais    = granges_file.to_make.map{it.get('fasta index file')}
 

--- a/workflows/genome_preparation/main.nf
+++ b/workflows/genome_preparation/main.nf
@@ -153,7 +153,7 @@ workflow genome_preparation {
 		granges_file.to_skip.dump(tag: 'genome_preparation:granges_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		genomes = granges_file.to_make.map{it.get('id')}
+		genomes = granges_file.to_make.map{it.get('name')}
 		gtfs    = granges_file.to_make.map{it.get('gtf file')}
 		fais    = granges_file.to_make.map{it.get('fasta index file')}
 

--- a/workflows/genome_preparation/main.nf
+++ b/workflows/genome_preparation/main.nf
@@ -49,26 +49,26 @@ workflow genome_preparation {
 				def has_fasta_path = it.containsKey('fasta path')
 				to_make: !has_fasta_file & has_fasta_path
 				to_skip: has_fasta_file | !has_fasta_path}
-			.set{fasta_files}
+			.set{fasta_file}
 
-		fasta_files.to_make.dump(tag: 'genome_preparation:fasta_files.to_make', pretty: true)
-		fasta_files.to_skip.dump(tag: 'genome_preparation:fasta_files.to_skip', pretty: true)
+		fasta_file.to_make.dump(tag: 'genome_preparation:fasta_file.to_make', pretty: true)
+		fasta_file.to_skip.dump(tag: 'genome_preparation:fasta_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		fasta_paths  = fasta_files.to_make.map{it.get('fasta path')}
-		output_files = fasta_files.to_make.map{it.get('id') + '.fa'}
+		fasta_paths  = fasta_file.to_make.map{it.get('fasta path')}
+		output_file = fasta_file.to_make.map{it.get('id') + '.fa'}
 
 		// run the process
-		cat_fastas([:], fasta_paths, output_files)
+		cat_fastas([:], fasta_paths, output_file)
 
 		// make a channel of newly created parameters
 		merge_process_emissions(cat_fastas, ['opt', 'path'])
 			.map{rename_map_keys(it, 'path', 'fasta file')}
 			.map{merge_metadata_and_process_output(it)}
-			.concat(fasta_files.to_skip)
+			.concat(fasta_file.to_skip)
 			.merge(genome_parameters)
 			.map{it.last() + it.first()}
-			.dump(tag: 'genome_preparation:fasta_files', pretty: true)
+			.dump(tag: 'genome_preparation:fasta_file', pretty: true)
 			.set{genome_parameters}
 
 		// -------------------------------------------------------------------------------------------------
@@ -82,25 +82,25 @@ workflow genome_preparation {
 				def has_fasta_index_file = it.containsKey('fasta index file')
 				to_make: has_fasta_file & !has_fasta_index_file
 				to_skip: !has_fasta_file | has_fasta_index_file}
-			.set{fasta_index_files}
+			.set{fasta_index_file}
 
-		fasta_index_files.to_make.dump(tag: 'genome_preparation:fasta_index_files.to_make', pretty: true)
-		fasta_index_files.to_skip.dump(tag: 'genome_preparation:fasta_index_files.to_skip', pretty: true)
+		fasta_index_file.to_make.dump(tag: 'genome_preparation:fasta_index_file.to_make', pretty: true)
+		fasta_index_file.to_skip.dump(tag: 'genome_preparation:fasta_index_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		input_files = fasta_index_files.to_make.map{it.get('fasta file')}
+		input_file = fasta_index_file.to_make.map{it.get('fasta file')}
 
 		// run the process
-		faidx([:], input_files)
+		faidx([:], input_file)
 
 		// make a channel of newly created parameters
 		merge_process_emissions(faidx, ['opt', 'path'])
 			.map{rename_map_keys(it, 'path', 'fasta index file')}
 			.map{merge_metadata_and_process_output(it)}
-			.concat(fasta_index_files.to_skip)
+			.concat(fasta_index_file.to_skip)
 			.merge(genome_parameters)
 			.map{it.last() + it.first()}
-			.dump(tag: 'genome_preparation:fasta_index_files', pretty: true)
+			.dump(tag: 'genome_preparation:fasta_index_file', pretty: true)
 			.set{genome_parameters}
 
 		// -------------------------------------------------------------------------------------------------
@@ -114,26 +114,26 @@ workflow genome_preparation {
 				def has_gtf_path = it.containsKey('gtf path')
 				to_make: !has_gtf_file & has_gtf_path
 				to_skip: has_gtf_file | !has_gtf_path}
-			.set{gtf_files}
+			.set{gtf_file}
 
-		gtf_files.to_make.dump(tag: 'genome_preparation:gtf_files.to_make', pretty: true)
-		gtf_files.to_skip.dump(tag: 'genome_preparation:gtf_files.to_skip', pretty: true)
+		gtf_file.to_make.dump(tag: 'genome_preparation:gtf_file.to_make', pretty: true)
+		gtf_file.to_skip.dump(tag: 'genome_preparation:gtf_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		gtf_paths    = gtf_files.to_make.map{it.get('gtf path')}
-		output_files = gtf_files.to_make.map{it.get('id') + '.gtf'}
+		gtf_paths    = gtf_file.to_make.map{it.get('gtf path')}
+		output_file = gtf_file.to_make.map{it.get('id') + '.gtf'}
 
 		// run the process
-		cat_gtfs([:], gtf_paths, output_files)
+		cat_gtfs([:], gtf_paths, output_file)
 
 		// make a channel of newly created parameters
 		merge_process_emissions(cat_gtfs, ['opt', 'path'])
 			.map{rename_map_keys(it, 'path', 'gtf file')}
 			.map{merge_metadata_and_process_output(it)}
-			.concat(gtf_files.to_skip)
+			.concat(gtf_file.to_skip)
 			.merge(genome_parameters)
 			.map{it.last() + it.first()}
-			.dump(tag: 'genome_preparation:gtf_files', pretty: true)
+			.dump(tag: 'genome_preparation:gtf_file', pretty: true)
 			.set{genome_parameters}
 
 		// -------------------------------------------------------------------------------------------------
@@ -147,15 +147,15 @@ workflow genome_preparation {
 				def has_gtf_file = it.containsKey('gtf file')
 				to_make: has_fasta_index_file & has_gtf_file
 				to_skip: !has_fasta_index_file | !has_gtf_file}
-		 	.set{granges_files}
+		 	.set{granges_file}
 
-		granges_files.to_make.dump(tag: 'genome_preparation:granges_files.to_make', pretty: true)
-		granges_files.to_skip.dump(tag: 'genome_preparation:granges_files.to_skip', pretty: true)
+		granges_file.to_make.dump(tag: 'genome_preparation:granges_file.to_make', pretty: true)
+		granges_file.to_skip.dump(tag: 'genome_preparation:granges_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		genomes = granges_files.to_make.map{it.get('id')}
-		gtfs    = granges_files.to_make.map{it.get('gtf file')}
-		fais    = granges_files.to_make.map{it.get('fasta index file')}
+		genomes = granges_file.to_make.map{it.get('id')}
+		gtfs    = granges_file.to_make.map{it.get('gtf file')}
+		fais    = granges_file.to_make.map{it.get('fasta index file')}
 
 		// run the process
 		convert_gtf_to_granges([:], genomes, gtfs, fais)
@@ -163,10 +163,10 @@ workflow genome_preparation {
 		// make a channel of newly created parameters
 		merge_process_emissions(convert_gtf_to_granges, ['opt', 'granges'])
 			.map{merge_metadata_and_process_output(it)}
-			.concat(granges_files.to_skip)
+			.concat(granges_file.to_skip)
 			.merge(genome_parameters)
 			.map{it.last() + it.first()}
-			.dump(tag: 'genome_preparation:granges_files', pretty: true)
+			.dump(tag: 'genome_preparation:granges_file', pretty: true)
 			.set{genome_parameters}
 
 		// -------------------------------------------------------------------------------------------------
@@ -179,14 +179,14 @@ workflow genome_preparation {
 				def has_ensembl_release = it.containsKey('ensembl release')
 				to_make: has_ensembl_release
 				to_skip: !has_ensembl_release}
-			.set{mart_files}
+			.set{mart_file}
 
-		mart_files.to_make.dump(tag: 'genome_preparation:mart_files.to_make', pretty: true)
-		mart_files.to_skip.dump(tag: 'genome_preparation:mart_files.to_skip', pretty: true)
+		mart_file.to_make.dump(tag: 'genome_preparation:mart_file.to_make', pretty: true)
+		mart_file.to_skip.dump(tag: 'genome_preparation:mart_file.to_skip', pretty: true)
 
 		// make channels of parameters
-		organisms        = mart_files.to_make.map{it.get('organism')}
-		ensembl_releases = mart_files.to_make.map{it.get('ensembl release')}
+		organisms        = mart_file.to_make.map{it.get('organism')}
+		ensembl_releases = mart_file.to_make.map{it.get('ensembl release')}
 
 		// run the process
 		get_mart([:], organisms, ensembl_releases)
@@ -195,10 +195,10 @@ workflow genome_preparation {
 		merge_process_emissions(get_mart, ['opt', 'mart'])
 			.map{rename_map_keys(it, 'mart', 'biomart connection')}
 			.map{merge_metadata_and_process_output(it)}
-			.concat(mart_files.to_skip)
+			.concat(mart_file.to_skip)
 			.merge(genome_parameters)
 			.map{it.last() + it.first()}
-			.dump(tag: 'genome_preparation:mart_files', pretty: true)
+			.dump(tag: 'genome_preparation:mart_file', pretty: true)
 			.set{genome_parameters}
 
 		// -------------------------------------------------------------------------------------------------

--- a/workflows/genome_preparation/readme.yaml
+++ b/workflows/genome_preparation/readme.yaml
@@ -15,43 +15,43 @@ steps:
 
   - name: Make FastA index
     description: If not provided by the `fasta index file` parameter, the `fasta file` will be indexed using `samtools faidx`.
-    anchor: 76
+    anchor: 75
     modules:
       - samtools/faidx
 
   - name: Merge GTF files
     description: If provided and required, the GTF files in `gtf path` can be merged to provide the `gtf file` parameter. This is only used when `gtf file` is not already provided.
-    anchor: 106
+    anchor: 107
     modules:
       - tools/cat
 
   - name: Make GRanges object
-    description: Create a GRanges object using `genome`, `gtf file` and `fasta index file`.
-    anchor: 139
+    description: Create a GRanges object using the gneome `name`, `gtf file` and `fasta index file`.
+    anchor: 140
     modules:
       - R/GenomicRanges/convert_gtf_to_granges
 
   - name: Connect to biomaRt
     description: Creates a `mart` object to connect to the `organism` and `ensembl release` for the genome.
-    anchor: 171
+    anchor: 173
     modules:
       - R/biomaRt/get_mart
 
 output:
   - name: result
     type: channel
-    description: A parameters channel with datasets now including `fasta file`, `fasta index file`, `gtf file`, `granges` and `biomart connection` parameters.
+    description: A parameters channel with datasets now including additional genome parameters.
 
 channel tags:
-  - ':genome_parameters': The unique set of genome parameters used by datasets in the project.
+  - ':genome_parameters': The genome parameters used by datasets in the project.
   - ':fasta_file.{to_make,to_skip}': Genomes that provide `fasta path` but not `fasta file` or genomes that provide `fasta file` or lack `fasta path`.
-  - ':fasta_file': Genomes with `fasta file` provided, by some method.
+  - ':fasta_file': Parameters with `fasta file`.
   - ':fasta_index_file.{to_make,to_skip}': Genomes that do/not provide `fasta index file`.
-  - ':fasta_index_file': Genomes with `fasta index file`.
+  - ':fasta_index_file': Parameters with `fasta index file`.
   - ':gtf_file.{to_make,to_skip}': Genomes that provide `gtf path` but not `gtf file` or genomes that provide `gtf file` or lack `gtf path`.
-  - ':gtf_file': Genomes with `gtf file` provided, by some method.
+  - ':gtf_file': Parameters with `gtf file`.
   - ':granges_file.{to_make,to_skip}': Genomes that provide both `fasta index file` and `gtf file` will have a GRanges object created.
-  - ':granges_file': Channel of created GRanges object files.
+  - ':granges_file': Parameters with GRanges object file.
   - ':mart_file.{to_make,to_skip}': Genomes that provide an `ensembl release` will have a biomaRt connection created.
   - ':mart_file': Channel of `mart` objects.
   - ':result': Channel containing all of the parameters with these new keys added.

--- a/workflows/genome_preparation/readme.yaml
+++ b/workflows/genome_preparation/readme.yaml
@@ -44,16 +44,16 @@ output:
 
 channel tags:
   - ':genome_parameters': The unique set of genome parameters used by datasets in the project.
-  - ':fasta_paths.{to_make,to_skip}': Genomes that provide `fasta path` but not `fasta file` or genomes that provide `fasta file` or lack `fasta path`.
-  - ':fasta_files': Genomes with `fasta file` provided, by some method.
-  - ':fasta_index_files.{to_make,to_skip}': Genomes that do/not provide `fasta index file`.
-  - ':indexed_fasta_files': Genomes with `fasta index file`.
-  - ':gtf_files.{to_make,to_skip}': Genomes that provide `gtf path` but not `gtf file` or genomes that provide `gtf file` or lack `gtf path`.
-  - ':gtf_files': Genomes with `gtf file` provided, by some method.
-  - ':granges_files.{to_make,to_skip}': Genomes that provide both `fasta index file` and `gtf file` will have a GRanges object created.
-  - ':granges_files': Channel of created GRanges object files.
-  - ':mart_files.{to_make,to_skip}': Genomes that provide an `ensembl release` will have a biomaRt connection created.
-  - ':mart_files': Channel of `mart` objects.
+  - ':fasta_file.{to_make,to_skip}': Genomes that provide `fasta path` but not `fasta file` or genomes that provide `fasta file` or lack `fasta path`.
+  - ':fasta_file': Genomes with `fasta file` provided, by some method.
+  - ':fasta_index_file.{to_make,to_skip}': Genomes that do/not provide `fasta index file`.
+  - ':fasta_index_file': Genomes with `fasta index file`.
+  - ':gtf_file.{to_make,to_skip}': Genomes that provide `gtf path` but not `gtf file` or genomes that provide `gtf file` or lack `gtf path`.
+  - ':gtf_file': Genomes with `gtf file` provided, by some method.
+  - ':granges_file.{to_make,to_skip}': Genomes that provide both `fasta index file` and `gtf file` will have a GRanges object created.
+  - ':granges_file': Channel of created GRanges object files.
+  - ':mart_file.{to_make,to_skip}': Genomes that provide an `ensembl release` will have a biomaRt connection created.
+  - ':mart_file': Channel of `mart` objects.
   - ':result': Channel containing all of the parameters with these new keys added.
 
 authors:

--- a/workflows/quantification/cell_ranger/main.nf
+++ b/workflows/quantification/cell_ranger/main.nf
@@ -31,7 +31,7 @@ workflow cell_ranger {
 
 		// branch parameters into two channels: {missing,provided} according to the presence of the 'index path' key
 		parameters
-			.map{it.get('genome parameters').subMap(['key', 'assembly', 'fasta file', 'gtf file']) + it.subMap('index path')}
+			.map{it.get('genome parameters').subMap(['id', 'fasta file', 'gtf file']) + it.subMap('index path')}
 			.unique()
 			.branch{
 				def index_provided = it.containsKey('index path')
@@ -43,8 +43,8 @@ workflow cell_ranger {
 		genome_indexes.provided.dump(tag: 'quantification:cell_ranger:genome_indexes.provided', pretty: true)
 
 		// make channels of parameters for genomes that need indexes to be created
-		tags        = genome_indexes.missing.map{it.get('key')}
-		assemblies  = genome_indexes.missing.map{it.get('assembly')}
+		tags        = genome_indexes.missing.map{it.get('id')}
+		assemblies  = genome_indexes.missing.map{it.get('id')}
 		fasta_files = genome_indexes.missing.map{it.get('fasta file')}
 		gtf_files   = genome_indexes.missing.map{it.get('gtf file')}
 
@@ -66,7 +66,6 @@ workflow cell_ranger {
 		// make a channel containing all information for the quantification process
 		parameters
 			.combine(index_paths)
-			.filter{it.first().get('genome') == it.last().get('key')}
 			.map{it.first() + it.last().subMap('index path')}
 			.map{it.subMap(['unique id', 'dataset id', 'description', 'limsid', 'fastq paths', 'index path'])}
 			.dump(tag: 'quantification:cell_ranger:datasets_to_quantify', pretty: true)

--- a/workflows/quantification/cell_ranger/readme.yaml
+++ b/workflows/quantification/cell_ranger/readme.yaml
@@ -10,10 +10,11 @@ tags:
 
 steps:
   - name: Make genome index
-    description: Use `cellranger mkref` to make an index against which expression can be quantified using `fasta file` and `gtf file`.
+    description: Use `cellranger mkref` to make an index against which expression can be quantified using `fasta file` and `gtf file`. The output index is named using the `id` key.
     anchor: 29
     modules:
       - cell_ranger/mkref
+
   - name: Quantify expression
     description: Run `cellranger count` to align and quantify gene expression using the FastQ files and a genome index.
     anchor: 63

--- a/workflows/quantification/cell_ranger_arc/main.nf
+++ b/workflows/quantification/cell_ranger_arc/main.nf
@@ -31,7 +31,7 @@ workflow cell_ranger_arc {
 
 		// branch parameters into two channels: {missing,provided} according to the presence of the 'index path' key
 		parameters
-			.map{it.get('genome parameters').subMap(['key', 'organism', 'assembly', 'non-nuclear contigs', 'motifs file', 'fasta file', 'gtf file']) + it.subMap('index path')}
+			.map{it.get('genome parameters').subMap(['id', 'organism', 'non-nuclear contigs', 'motifs file', 'fasta file', 'gtf file']) + it.subMap('index path')}
 			.unique()
 			.branch{
 				def index_provided = it.containsKey('index path')
@@ -43,9 +43,9 @@ workflow cell_ranger_arc {
 		genome_indexes.provided.dump(tag: 'quantification:cell_ranger_arc:genome_indexes.provided', pretty: true)
 
 		// make channels of parameters for genomes that need indexes to be created
-		tags                = genome_indexes.missing.map{it.get('key')}
+		tags                = genome_indexes.missing.map{it.get('id')}
 		organisms           = genome_indexes.missing.map{it.get('organism')}
-		assemblies          = genome_indexes.missing.map{it.get('assembly')}
+		assemblies          = genome_indexes.missing.map{it.get('id')}
 		non_nuclear_contigs = genome_indexes.missing.map{it.get('non-nuclear contigs')}
 		motifs_files        = genome_indexes.missing.map{it.get('motifs file')}
 		fasta_files         = genome_indexes.missing.map{it.get('fasta file')}
@@ -94,7 +94,6 @@ workflow cell_ranger_arc {
 		// make a channel containing all information for the quantification process
 		parameters
 			.combine(index_paths)
-			.filter{it.first().get('genome') == it.last().get('key')}
 			.map{it.first() + it.last().subMap('index path')}
 			.map{it.subMap(['unique id', 'dataset id', 'description', 'limsid', 'index path'])}
 			.dump(tag: 'quantification:cell_ranger_arc:datasets_to_quantify', pretty: true)
@@ -127,8 +126,8 @@ workflow cell_ranger_arc {
 			.filter{check_for_matching_key_values(it, ['unique id'])}
 			.map{it.first() + it.last().subMap(['index path', 'libraries_csv', 'quantification path'])}
 			.map{it + ['quantification method': 'cell_ranger_arc']}
-			.dump(tag: 'quantification:cell_ranger_arc:final_results', pretty: true)
-			.set{final_results}
+			.dump(tag: 'quantification:cell_ranger_arc:result', pretty: true)
+			.set{result}
 
 		// -------------------------------------------------------------------------------------------------
 		// make summary report for cell ranger arc stage
@@ -151,6 +150,6 @@ workflow cell_ranger_arc {
 		// TODO: add process to render a chapter of a report
 
 	emit:
-		result = final_results
+		result = result
 		report = channel.of('report.document')
 }

--- a/workflows/quantification/cell_ranger_arc/readme.yaml
+++ b/workflows/quantification/cell_ranger_arc/readme.yaml
@@ -14,6 +14,7 @@ steps:
     anchor: 29
     modules:
       - cell_ranger_arc/mkref
+
   - name: Create project sample sheet
     description: Write a formatted configuration file that includes all libraries in this project which will be subset for libraries in a dataset.
     anchor: 66
@@ -32,13 +33,13 @@ output:
     description: A channel of maps that are the same as the input parameter sets but now include `index path`, `quantification method` and `quantification path` keys.
 
 channel tags:
-  - ':genome_indexes.missing': Datasets for which the `index path` is missing, indexes will be created for these.
+  - ':genome_indexes.missing': Datasets for which the `index path` is missing; indexes will be created for these.
   - ':genome_indexes.provided': Datasets for which the `index path` has been provided.
   - ':index_paths': The indexes that have been created or provided.
   - ':feature_type_params': A channel that collates the project-wide information required to make the Cell Ranger ARC sample sheet.
   - ':datasets_to_quantify': Parameter sets for datasets that will be quantified.
   - ':quantified_datasets': Parameter sets of datasets that were quantified.
-  - ':final_results': Input parameters with the `index path` (if applicable), `libraries_csv`, `quantification method` and `quantification path` keys added.
+  - ':final_result': Input parameters with the `index path` (if applicable), `libraries_csv`, `quantification method` and `quantification path` keys added.
 
 authors:
   - "@ChristopherBarrington"

--- a/workflows/quantification/main.nf
+++ b/workflows/quantification/main.nf
@@ -52,8 +52,8 @@ workflow quantification {
 		// concatenate output channels from each subworkflow
 		concat_workflow_emissions(all_quantifications, 'result')
 			.concat(quantification.unknown)
-			.set{all_results}
+			.set{result}
 
 	emit:
-		result = all_results
+		result = result
 }

--- a/workflows/seurat/main.nf
+++ b/workflows/seurat/main.nf
@@ -26,8 +26,8 @@ workflow seurat {
 		parameters
 			.branch{
 				def seurat_provided = it.containsKey('seurat file')
-				provided: seurat_provided == true
-				required: seurat_provided == false}
+				provided: seurat_provided
+				required: !seurat_provided}
 			.set{objects}
 
 		objects.required.dump(tag: 'seurat:objects.required', pretty: true)

--- a/workflows/seurat/prepare/cell_ranger/main.nf
+++ b/workflows/seurat/prepare/cell_ranger/main.nf
@@ -139,8 +139,8 @@ workflow cell_ranger {
 			.combine(objects)
 			.filter{check_for_matching_key_values(it, ['unique id'])}
 			.map{it.first() + ['seurat path': it.last().subMap(['seurat'])]}
-			.dump(tag: 'seurat:prepare:cell_ranger:final_results', pretty: true)
-			.set{final_results}
+			.dump(tag: 'seurat:prepare:cell_ranger:result', pretty: true)
+			.set{result}
 
 		// -------------------------------------------------------------------------------------------------
 		// make summary report for cell ranger arc stage
@@ -169,6 +169,6 @@ workflow cell_ranger {
 		// TODO: add process to render a chapter of a report
 
 	emit:
-		result = final_results
+		result = result
 		report = channel.of('report.document')
 }

--- a/workflows/seurat/prepare/cell_ranger/main.nf
+++ b/workflows/seurat/prepare/cell_ranger/main.nf
@@ -40,7 +40,7 @@ workflow cell_ranger {
 
 		// get the unique set of quantification matrices and feature identifiers' columns
 		parameters
-			.map{[it.subMap('dataset id', 'index path', 'quantification path'), ['accession', 'name']]}
+			.map{[it.subMap('dataset id', 'quantification path'), ['accession', 'name']]}
 			.transpose()
 			.map{it.first() + [identifier: it.last(), 'matrix state': 'filtered']}
 			.unique()
@@ -102,8 +102,7 @@ workflow cell_ranger {
 		// combine the annotations and rna assays into a channel
 		parameters
 			.combine(rna_assays)
-			.combine(barcoded_matrices.filter{it.get('identifier') == 'accession'}.map{it.subMap(['index path', 'quantification path', 'features'])})
-			.filter{check_for_matching_key_values(it, 'index path')}
+			.combine(barcoded_matrices.filter{it.get('identifier') == 'accession'}.map{it.subMap(['quantification path', 'features'])})
 			.filter{check_for_matching_key_values(it, 'quantification path')}
 			.map{concatenate_maps_list(it)}
 			.map{it + [ordered_assays: it.subMap('rna_assay_by_accession', 'rna_assay_by_name').values().toList()]}

--- a/workflows/seurat/prepare/cell_ranger/readme.yaml
+++ b/workflows/seurat/prepare/cell_ranger/readme.yaml
@@ -35,7 +35,7 @@ channel tags:
   - ':rna_assays': Merge of accession- and name-indexed assays.
   - ':objects_to_create': Parameters used to create Seurat objects.
   - ':objects': Paths to created Seurat objects.
-  - ':final_results': Input parameters with `seurat path` key added.
+  - ':final_result': Input parameters with `seurat path` key added.
 
 authors:
   - "@ChristopherBarrington"

--- a/workflows/seurat/prepare/cell_ranger_arc/main.nf
+++ b/workflows/seurat/prepare/cell_ranger_arc/main.nf
@@ -172,8 +172,8 @@ workflow cell_ranger_arc {
 			.combine(objects)
 			.filter{check_for_matching_key_values(it, ['unique id'])}
 			.map{it.first() + ['seurat path': it.last().subMap(['seurat'])]}
-			.dump(tag: 'seurat:prepare:cell_ranger_arc:final_results', pretty: true)
-			.set{final_results}
+			.dump(tag: 'seurat:prepare:cell_ranger_arc:result', pretty: true)
+			.set{result}
 
 		// -------------------------------------------------------------------------------------------------
 		// make summary report for cell ranger arc stage
@@ -202,6 +202,6 @@ workflow cell_ranger_arc {
 		// TODO: add process to render a chapter of a report
 
 	emit:
-		result = final_results
+		result = result
 		report = channel.of('report.document')
 }

--- a/workflows/seurat/prepare/cell_ranger_arc/main.nf
+++ b/workflows/seurat/prepare/cell_ranger_arc/main.nf
@@ -42,7 +42,7 @@ workflow cell_ranger_arc {
 
 		// get the unique set of quantification matrices and feature identifiers' columns
 		parameters
-			.map{[it.subMap('dataset id', 'index path', 'quantification path'), ['accession', 'name']]}
+			.map{[it.subMap('dataset id', 'quantification path'), ['accession', 'name']]}
 			.transpose()
 			.map{it.first() + [identifier: it.last(), 'matrix state': 'filtered']}
 			.unique()
@@ -134,8 +134,7 @@ workflow cell_ranger_arc {
 		parameters
 			.combine(rna_assays)
 			.combine(chromatin_assays)
-			.combine(barcoded_matrices.filter{it.get('identifier') == 'accession'}.map{it.subMap(['index path', 'quantification path', 'features'])})
-			.filter{check_for_matching_key_values(it, 'index path')}
+			.combine(barcoded_matrices.filter{it.get('identifier') == 'accession'}.map{it.subMap(['quantification path', 'features'])})
 			.filter{check_for_matching_key_values(it, 'quantification path')}
 			.map{concatenate_maps_list(it)}
 			.map{it + [ordered_assays: it.subMap('rna_assay_by_accession', 'rna_assay_by_name').values().toList()]}

--- a/workflows/seurat/prepare/cell_ranger_arc/readme.yaml
+++ b/workflows/seurat/prepare/cell_ranger_arc/readme.yaml
@@ -37,7 +37,7 @@ channel tags:
   - ':chromatin_assays': Paths to the created chromatin accessibility assays.
   - ':objects_to_create': Parameters used to create Seurat objects.
   - ':objects': Paths to created Seurat objects.
-  - ':final_results': Input parameters with `seurat path` key added.
+  - ':final_result': Input parameters with `seurat path` key added.
 
 authors:
   - "@ChristopherBarrington"


### PR DESCRIPTION
* removes genomes as a list of stanza and uses only one `_genome`
* updates guess parameters script
* updates get (parse) parameters utility; fixes ordering and default values
* updates workflows, no longer need to check for genome version
* updates genome preparation
* remove unique id parameter, now dataset id is unique
* remove genome `name` key, use assembly or id
* remove index path from non-quantification workflows - fasta/gtf supplied in the genome