### PR TITLE
fix cell ranger mkref editing gtf

### DIFF
--- a/modules/cell_ranger/mkref/templates/main.sh
+++ b/modules/cell_ranger/mkref/templates/main.sh
@@ -1,13 +1,13 @@
 #! bash
 
 # rename any gene_biotype keys to gene_type
-sed --in-place 's/ gene_biotype / gene_type /' features.gtf
+sed 's/ gene_biotype / gene_type /' features.gtf > parsed_features.gtf
 
 # create the index
 cellranger mkref $mkref_args \\
     --genome $assembly \\
     --fasta assembly.fasta \\
-    --genes features.gtf \\
+    --genes parsed_features.gtf \\
 	--nthreads ${task.cpus} \\
 	--memgb ${task.memory.toGiga()}
 
@@ -22,7 +22,7 @@ cat <<-END_TASK > task.yaml
 "${task.process}":
     assembly: $assembly
     assembly_fasta: `pwd`/assembly.fasta
-    features_gtf: `pwd`/features.gtf
+    features_gtf: `pwd`/parsed_features.gtf
     task_index: ${task.index}
     ext:
         mkref: ${mkref_args}

--- a/modules/cell_ranger_arc/mkref/templates/main.sh
+++ b/modules/cell_ranger_arc/mkref/templates/main.sh
@@ -1,7 +1,7 @@
 #! bash
 
 # rename any gene_biotype keys to gene_type
-sed --in-place 's/ gene_biotype / gene_type /' features.gtf
+sed 's/ gene_biotype / gene_type /' features.gtf > parsed_features.gtf
 
 # reformat non-nuclear contigs
 NON_NUCLEAR_CONTIGS=`echo -n $non_nuclear_contigs | sed --regexp-extended 's/\\[|,|\\]//g' | jq -R -s -c 'split(" ")'`
@@ -12,7 +12,7 @@ cat <<-CONFIG > config
     organism: "$organism"
     genome: ["$assembly"]
     input_fasta: ["assembly.fasta"]
-    input_gtf: ["features.gtf"]
+    input_gtf: ["parsed_features.gtf"]
     input_motifs: "motifs.txt"
     non_nuclear_contigs: \${NON_NUCLEAR_CONTIGS}
 }
@@ -36,7 +36,7 @@ cat <<-END_TASK > task.yaml
     organism: $organism
     assembly: $assembly
     assembly_fasta: `pwd`/assembly.fasta
-    features_gtf: `pwd`/features.gtf
+    features_gtf: `pwd`/parsed_features.gtf
     task_index: ${task.index}
     ext:
         mkref: ${mkref_args}


### PR DESCRIPTION
* used `sed` to modify gtf in-place but this would edit a shared or output file
* redirect `sed` output to `parsed_features.gtf` and pass that file to cell ranger
* any modifications can be applied to `parsed_features.gtf`
* affected both cell ranger and cell ranger arc mkref modules